### PR TITLE
Switch no-unsupported-features to version 6

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -35,7 +35,7 @@
     "template-curly-spacing": ["error", "never"],
     "semi-spacing": "error",
     "strict": "error",
-    "node/no-unsupported-features": ["error", { "version": 4 }],
+    "node/no-unsupported-features": ["error", { "version": 6 }],
     "node/no-missing-require": "error"
   }
 }


### PR DESCRIPTION
The geocoding family of modules hard-depends on node 6 and currently uses some node-6-isms that it probably isn't worth rewriting away in the interests of conforming to the current node-4 rule. This PR changes it to 6. I don't think this one is controversial but would welcome people speaking up if they have particular objections to any 6-specific features. A good overview is [here](https://github.com/mysticatea/eslint-plugin-node/blob/HEAD/docs/rules/no-unsupported-features.md).

(Counterpoint: we could also set it even higher. I don't think we have need for the extras in 6.5 though, and 7 or 8 is probably overly aggressive at this point.)