### PR TITLE
Set prefer-const.destructuring = "all"

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -11,7 +11,7 @@
     "no-console":0,
     "arrow-parens": ["error", "always"],
     "no-var": "error",
-    "prefer-const": "error",
+    "prefer-const": ["error", { "destructuring": "all" }],
     "array-bracket-spacing": ["error", "never"],
     "comma-dangle": ["error", "never"],
     "computed-property-spacing": ["error", "never"],


### PR DESCRIPTION
Our current settings for `prefer-const` accept the default value of `"destructuring"="any"`.  I came across an example of a time when this restriction can be a little awkward: destructuring `Map` objects.  From [`carmen/lib/util/dawg.js`](https://github.com/mapbox/carmen/blob/821fa9c8ce4557e95ddae0381915b394e841dc12/lib/util/dawg.js#L89-L99):

```javascript
    for (let [key, values] of this.normalizationMap) {
        // if this key maps to both itself and other values, add itself to the set
        if (mapsToSelf.has(key)) {
            values = new Set([...values, key]);
        }

        normData.push([
            normalizationIndexes.get(key),
            Array.from(values).map((v) => { return normalizationIndexes.get(v); }).sort(),
        ]);
    }
```

this raises the linter error:

```
'key' is never reassigned. Use 'const' instead. (prefer-const)
```

Changing the code to satisfy this constraint feels a little dumb. Meanwhile, changing the behavior of `prefer-const` for destructuring cases is possible, so I'm proposing we take advantage.