### PR TITLE
Lint the linter. Update deprecated rule.

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -21,7 +21,7 @@
     "no-confusing-arrow": ["error", { "allowParens": false }],
     "no-extend-native": "error",
     "no-mixed-spaces-and-tabs": "error",
-    "no-spaced-func": "error",
+    "func-call-spacing": ["error", "never"],
     "no-trailing-spaces": "error",
     "no-unused-vars": "error",
     "no-use-before-define": ["error", "nofunc"],

--- a/test/fixtures/cracklepop-valid.js
+++ b/test/fixtures/cracklepop-valid.js
@@ -1,20 +1,20 @@
 'use strict';
 
 function cracklePop() {
-  let i;
-  let text = '';
-  for (i = 0; i < 101; i++) {
-    if (i % 5 === 0 && i % 3 === 0) {
-      text += 'CracklePop\n';
-    } else if (i % 3 === 0) {
-      text += 'Crackle\n';
-    } else if (i % 5 === 0) {
-      text += 'Pop\n';
-    } else {
-      text += i + '\n';
+    let i;
+    let text = '';
+    for (i = 0; i < 101; i++) {
+        if (i % 5 === 0 && i % 3 === 0) {
+            text += 'CracklePop\n';
+        } else if (i % 3 === 0) {
+            text += 'Crackle\n';
+        } else if (i % 5 === 0) {
+            text += 'Pop\n';
+        } else {
+            text += i + '\n';
+        }
     }
-  }
-  console.log(text);
+    console.log(text);
 }
 
 cracklePop();

--- a/test/test.js
+++ b/test/test.js
@@ -5,14 +5,14 @@ const cli = new CLIEngine({ configFile: `${__dirname}/../eslintrc.json` });
 const tape = require('tape');
 
 tape('test config with invalid js', (assert) => {
-  const report = cli.executeOnFiles([`${__dirname}/fixtures/cracklepop-invalid.js`]);
-  assert.equal(report.errorCount, 34, 'finds errors in invalid file');
-  assert.end();
+    const report = cli.executeOnFiles([`${__dirname}/fixtures/cracklepop-invalid.js`]);
+    assert.equal(report.errorCount, 14, 'finds errors in invalid file');
+    assert.end();
 });
 
 tape('test config with valid js', (assert) => {
-  const report = cli.executeOnFiles([`${__dirname}/fixtures/cracklepop-valid.js`]);
-  assert.equal(report.errorCount, 0, 'finds no errors in valid file');
-  assert.end();
+    const report = cli.executeOnFiles([`${__dirname}/fixtures/cracklepop-valid.js`]);
+    assert.equal(report.errorCount, 0, 'finds no errors in valid file');
+    assert.end();
 });
 


### PR DESCRIPTION
Two main changes:

1. Update the valid test fixture to actually be valid, and correct the
number of errors in the invalid test fixture. Looks like the 2 vs 4
space rule wasn't being applied properly

2. Replace the deprecated `no-spaced-func` rule with the current
equivalent, `func-call-spacing`. Deprecated rules aren't removed from
ESLint, so it still works, but they're not maintained and ESLint
recommends updating. In this case the new version is more flexible and
allows both `always` and `never` values, rather than just `never`.

cc @mapbox/geocoding-gang 